### PR TITLE
[#27] BackgroundTick, ForegroundTick 분리

### DIFF
--- a/src/backend/state.rs
+++ b/src/backend/state.rs
@@ -9,7 +9,6 @@ pub enum BackgroundLoopEvent {
     Resume,
     Next,
     Previous,
-    Tick,
 }
 
 #[derive(Debug, Clone)]

--- a/src/frontend/mod.rs
+++ b/src/frontend/mod.rs
@@ -155,10 +155,6 @@ impl MainApp {
                 self.update_music_list_from_config();
             }
             ForegroundEvent::Tick(_) => {
-                if let Err(error) = self.background_event_sender.send(BackgroundLoopEvent::Tick) {
-                    println!("Failed to send event: {:?}", error);
-                }
-
                 let current_music_index = self
                     .background_state
                     .current_music_index


### PR DESCRIPTION
resolved: #27 

기존에는 iced::subscription 기반의 tick loop를 사용했는데, 이건 foreground 상태에서만 활성화되는 기능이라서 백그라운드 모드에서는 동작하지 않음.

그래서 그냥 백그라운드 tick을 따로 분리함. 